### PR TITLE
Overload Traduction

### DIFF
--- a/structure/template/_core/helpers/language.js
+++ b/structure/template/_core/helpers/language.js
@@ -1,4 +1,31 @@
+const globalConfig = require('@config/global');
+const fs = require('node:fs');
+const path = require('node:path');
 const languages = [];
+
+
+function deepFindObject(obj, key) {
+	if(typeof obj === 'undefined') {
+		return undefined;
+	}
+	const parts = key.split(".");
+    if (parts.length == 1){
+        return obj[parts[0]];
+    }
+    return deepFindObject(obj[parts[0]], parts.slice(1).join("."));
+};
+
+function getOverloadFile(filePath) {
+	if(fs.existsSync(filePath) && fs.lstatSync(filePath).isFile()) {
+		try {
+			return require(filePath);
+		} catch (err) {
+			return {};
+		}
+	} else {
+		return {};
+	}
+}
 
 function fetchText(key, params, lang) {
 	if (!key)
@@ -20,9 +47,15 @@ function fetchText(key, params, lang) {
 		}
 	}
 
+	// Dans global.js mettre une clé "overload_trad" qui sera le du dossier ou l'on aura la traduction
+	// Par defaut le dossier se nomme : overload (il n'est pas nécessaire de mettre la clé dans global.js)
+	const overloadKey = globalConfig?.overload_trad ? globalConfig.overload_trad : "overload";
+	const overloadDepth = getOverloadFile(path.join(__dirname + `../../../app/locales/${overloadKey}/${lang}.json`));
 	let depth = languages[lang];
+
 	for (let i = 0; i < keys.length; i++) {
-		depth = depth[keys[i]];
+		// Permet de lire en premier le fichier de surcharge.
+		depth = deepFindObject(overloadDepth, key) || depth[keys[i]];
 		if (typeof depth === 'undefined')
 			return key;
 	}


### PR DESCRIPTION
Surcharge des traductions :

Par defaut :
- dans le dossier "locales" créer un sous dossier "overload". 
- dans dans ce sous dossier créer les fichier JSON nécessaire (exemple: fr-FR.json ou en-EN.json)
- dans chaque JSON mettre seulement le clé nécessaire en gardant la même structure que le fichier classique

Si on souhaite plusieurs dossiers différents (Différent client) :
- dans le dossier "locales" créer un sous dossier avec le nom souhaité (sans espace) ==> exemple : "agir"
- dans le fichier "global.js" mettre une clé "overload_trad" et mettre comme valeur le nom du dossier créer
- pour les fichiers JSON faire comme au-dessus