### PR TITLE
FIX e_media_mail insertVariablesValue / getCustomData

### DIFF
--- a/structure/pieces/component/status/models/e_media_mail.js
+++ b/structure/pieces/component/status/models/e_media_mail.js
@@ -1,15 +1,15 @@
-const CoreModel = require('@core/models/model');
+const CoreModel = require("@core/models/model");
 const attributes = require("./attributes/e_media_mail.json");
 const relations = require("./options/e_media_mail.json");
-const mailer = require('@core/services/mailer.js');
-const dayjs = require('dayjs');
-const globalConf = require('@config/global');
+const mailer = require("@core/services/mailer.js");
+const dayjs = require("dayjs");
+const globalConf = require("@config/global");
 
-const INSERT_USER_GROUP_FIELDS = ['f_from', 'f_to', 'f_cc', 'f_cci', 'f_attachments'];
+const INSERT_USER_GROUP_FIELDS = ["f_from", "f_to", "f_cc", "f_cci", "f_attachments"];
 
 class E_media_mail extends CoreModel {
 	constructor() {
-		super('E_media_mail', 'e_media_mail', attributes, relations);
+		super("E_media_mail", "e_media_mail", attributes, relations);
 	}
 
 	setInstanceMethods(sequelizeModel) {
@@ -18,12 +18,12 @@ class E_media_mail extends CoreModel {
 	}
 
 	parseForInclude() {
-		const fieldsToParse = ['f_from', 'f_to', 'f_cc', 'f_cci', 'f_subject', 'f_content', 'f_attachments'];
+		const fieldsToParse = ["f_from", "f_to", "f_cc", "f_cci", "f_subject", "f_content", "f_attachments"];
 		const valuesForInclude = [];
 		for (let i = 0; i < fieldsToParse.length; i++) {
-			const regex = new RegExp(/{field\|([^}]*)}/g);let matches = null;
-			while ((matches = regex.exec(this[fieldsToParse[i]])) != null)
-				valuesForInclude.push(matches[1]);
+			const regex = new RegExp(/{field\|([^}]*)}/g);
+			let matches = null;
+			while ((matches = regex.exec(this[fieldsToParse[i]])) != null) valuesForInclude.push(matches[1]);
 		}
 		return valuesForInclude;
 	}
@@ -42,27 +42,28 @@ class E_media_mail extends CoreModel {
 				// FETCH GROUP EMAIL
 				{
 					// Exctract all group IDs from property to find them all at once
-					const groupRegex = new RegExp(/{(group\|[^}]*)}/g);let match = null;
+					const groupRegex = new RegExp(/{(group\|[^}]*)}/g);
+					let match = null;
 					while ((match = groupRegex.exec(self[property])) != null) {
-						const placeholderParts = match[1].split('|');
-						const groupId = parseInt(placeholderParts[placeholderParts.length-1]);
-						intermediateData['group'+groupId] = {placeholder: match[0], emails: []};
+						const placeholderParts = match[1].split("|");
+						const groupId = parseInt(placeholderParts[placeholderParts.length - 1]);
+						intermediateData["group" + groupId] = { placeholder: match[0], emails: [] };
 						groupIds.push(groupId);
 					}
 
 					// Fetch all groups found and their users
 					/* eslint-disable */
 					const groups = await self.sequelize.models.E_group.findAll({
-						where: {id: {[self.sequelize.models.$in]: groupIds}},
-						include: {model: self.sequelize.models.E_user, as: 'r_user'}
+						where: { id: { [self.sequelize.models.$in]: groupIds } },
+						include: { model: self.sequelize.models.E_user, as: "r_user" },
 					});
 					/* eslint-enable */
 
 					// Exctract email and build intermediateData object used to replace placeholders
 					for (let i = 0; i < groups.length; i++) {
-						const intermediateKey = 'group'+groups[i].id;
+						const intermediateKey = "group" + groups[i].id;
 						for (let j = 0; j < groups[i].r_user.length; j++)
-							if (groups[i].r_user[j].f_email && groups[i].r_user[j].f_email != '') {
+							if (groups[i].r_user[j].f_email && groups[i].r_user[j].f_email != "") {
 								intermediateData[intermediateKey].emails.push(groups[i].r_user[j].f_email);
 								userMails.push(groups[i].r_user[j].f_email);
 							}
@@ -72,25 +73,26 @@ class E_media_mail extends CoreModel {
 				// FETCH USER EMAIL
 				{
 					// Exctract all user IDs from property to find them all at once
-					const userRegex = new RegExp(/{(user\|[^}]*)}/g);let match = null;
+					const userRegex = new RegExp(/{(user\|[^}]*)}/g);
+					let match = null;
 					while ((match = userRegex.exec(self[property])) != null) {
-						const placeholderParts = match[1].split('|');
-						const userId = parseInt(placeholderParts[placeholderParts.length-1]);
-						intermediateData['user'+userId] = {placeholder: match[0], emails: []};
+						const placeholderParts = match[1].split("|");
+						const userId = parseInt(placeholderParts[placeholderParts.length - 1]);
+						intermediateData["user" + userId] = { placeholder: match[0], emails: [] };
 						userIds.push(userId);
 					}
 
 					// Fetch all users found
 					/* eslint-disable */
 					const users = await self.sequelize.models.E_user.findAll({
-						where: {id: {[self.sequelize.models.$in]: userIds}}
+						where: { id: { [self.sequelize.models.$in]: userIds } },
 					});
 					/* eslint-enable */
 
 					// Exctract email and build intermediateData object used to replace placeholders
 					for (let i = 0; i < users.length; i++) {
-						const intermediateKey = 'user'+users[i].id;
-						if (users[i].f_email && users[i].f_email != '') {
+						const intermediateKey = "user" + users[i].id;
+						if (users[i].f_email && users[i].f_email != "") {
 							intermediateData[intermediateKey].emails.push(users[i].f_email);
 							userMails.push(users[i].f_email);
 						}
@@ -100,15 +102,15 @@ class E_media_mail extends CoreModel {
 				// Replace each occurence of {group|label|id} and {user|label|id} placeholders by their built emails list
 				for (const prop in intermediateData) {
 					// Escape placeholder and use it as a regex key to execute the replace on self[property]
-					const regKey = intermediateData[prop].placeholder.replace(new RegExp('[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\-]', 'g'), '\\$&')
+					const regKey = intermediateData[prop].placeholder.replace(new RegExp("[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\-]", "g"), "\\$&");
 					// Replace globaly
-					const reg = new RegExp(regKey, 'g');
-					self[property] = self[property].replace(reg, intermediateData[prop].emails.join(';'));
+					const reg = new RegExp(regKey, "g");
+					self[property] = self[property].replace(reg, intermediateData[prop].emails.join(";"));
 				}
 			}
 		}
 
-		function getFilePath(filename){
+		function getFilePath(filename) {
 			const filePath = globalConf.localstorage + filename;
 			return filePath;
 		}
@@ -116,20 +118,16 @@ class E_media_mail extends CoreModel {
 		function insertVariablesValue(property) {
 			// Recursive function to dive into relations object until matching field or nothing is found
 			function diveData(object, depths, idx) {
-				if (!object[depths[idx]])
-					return "";
-				else if (typeof object[depths[idx]] === 'object') {
-					if (object[depths[idx]] instanceof Date)
-						return dayjs(object[depths[idx]]).format("DD/MM/YYYY");
-
+				if (!object[depths[idx]]) return "";
+				else if (typeof object[depths[idx]] === "object") {
+					if (object[depths[idx]] instanceof Date) return dayjs(object[depths[idx]]).format("DD/MM/YYYY");
 					// Case where targeted field is in an array.
 					// Ex: r_projet.r_participants.f_email <- Loop through r_participants and join all f_email
-					else if (object[depths[idx]] instanceof Array && depths.length-2 == idx) {
+					else if (object[depths[idx]] instanceof Array && depths.length - 2 == idx) {
 						const values = [];
 						for (let i = 0; i < object[depths[idx]].length; i++)
-							if (typeof object[depths[idx]][i][depths[idx+1]] !== 'undefined')
-								values.push(object[depths[idx]][i][depths[idx+1]]);
-						return values.join(', ');
+							if (typeof object[depths[idx]][i][depths[idx + 1]] !== "undefined") values.push(object[depths[idx]][i][depths[idx + 1]]);
+						return values.join(", ");
 					}
 					return diveData(object[depths[idx]], depths, ++idx);
 				}
@@ -141,17 +139,17 @@ class E_media_mail extends CoreModel {
 			let matches = null;
 
 			// Need an array for attachments, not a string
-			if(property == 'f_attachments'){
+			if (property == "f_attachments") {
 				newString = [];
 				while ((matches = regex.exec(self[property])) != null)
 					newString.push({
-						filename: diveData(dataInstance, matches[1].split('.'), 0),
-						path: getFilePath(diveData(dataInstance, matches[1].split('.'), 0))
+						filename: diveData(dataInstance, matches[1].split("."), 0),
+						path: getFilePath(diveData(dataInstance, matches[1].split("."), 0)),
 					});
 				self[property] = newString || [];
 			} else {
 				while ((matches = regex.exec(self[property])) != null)
-					newString = newString.replace(matches[0], diveData(dataInstance, matches[1].split('.'), 0));
+					newString = newString.replace(matches[0], diveData(dataInstance, matches[1].split("."), 0));
 				self[property] = newString || "";
 			}
 
@@ -163,20 +161,19 @@ class E_media_mail extends CoreModel {
 		await insertGroupAndUserEmail();
 		// Build mail options and replace entity's fields
 		const options = {
-			from: insertVariablesValue('f_from'),
-			to: insertVariablesValue('f_to'),
-			cc: insertVariablesValue('f_cc'),
-			bcc: insertVariablesValue('f_cci'),
-			subject: insertVariablesValue('f_subject'),
-			data: dataInstance
+			from: insertVariablesValue("f_from"),
+			to: insertVariablesValue("f_to"),
+			cc: insertVariablesValue("f_cc"),
+			bcc: insertVariablesValue("f_cci"),
+			subject: insertVariablesValue("f_subject"),
+			data: dataInstance,
 		};
 
-		const attachmentsFile = insertVariablesValue('f_attachments');
+		const attachmentsFile = insertVariablesValue("f_attachments");
 
 		// Send mail
-		return await mailer.sendHtml(insertVariablesValue('f_content'), options, attachmentsFile)
+		return await mailer.sendHtml(insertVariablesValue("f_content"), options, attachmentsFile);
 	}
-
 }
 
 module.exports = E_media_mail;

--- a/structure/pieces/component/status/models/e_media_mail.js
+++ b/structure/pieces/component/status/models/e_media_mail.js
@@ -150,10 +150,9 @@ class E_media_mail extends CoreModel {
 			} else {
 				while ((matches = regex.exec(self[property])) != null)
 					newString = newString.replace(matches[0], diveData(dataInstance, matches[1].split("."), 0));
-				self[property] = newString || "";
 			}
 
-			return self[property];
+			return newString;
 		}
 
 		// Replace {group|id} and {user|id} placeholders before inserting variables


### PR DESCRIPTION
Lors de l'utilisation de e_media_mail.execute dans une boucle les customs variables n'étaient pas recalculé à chaque itération.

PB :
La première itération compute le contenu de f_content et remplace les variables customs par les valeur envoyé dans la methode execute.
Le résultat était enregistré dans la propriété de la classe f_content ce qui n'est pas nécessaire.
Les prochaines itérations n'était pas prise en compte car la propriete f_content était rempli avec les valeurs de la premiere iteration.
