### PR TITLE
FIX data-searchable datalist

### DIFF
--- a/structure/template/_core/public/js/nodeaTable.js
+++ b/structure/template/_core/public/js/nodeaTable.js
@@ -751,7 +751,11 @@ let NodeaTable = (function () {
 				if (typeof $(this).data("orderable") !== "undefined") columnDef.orderable = $(this).data("orderable");
 
 				// Needed to be done after destructuring in order to have columnDef.search key in columnDef obj
-				columnDef.searchable = !!columnDef.search;
+				if (typeof $(this).data("orderable") !== "undefined") {
+					columnDef.searchable = $(this).data("searchable");
+				} else {
+					columnDef.searchable = !!columnDef.search;
+				}
 
 				// COLUMN RENDER
 				const originalRender = columnDef.render;


### PR DESCRIPTION
L'attribut data-searchable n'est pas pris en compte dans nodeTable.

Il devrait l'être comme spécifié dans la documentation : https://docs.nodea-software.com/en/3-1/developer/client_side_js

Ceci règle le pb.